### PR TITLE
Store token auth in global settings

### DIFF
--- a/flowhub/engine.py
+++ b/flowhub/engine.py
@@ -68,7 +68,7 @@ class Engine(object):
             'Flowhub Client',
         )
         token = auth.token
-
+        # set the token globally, rather than on the repo level.
         authing = commands.getoutput('git config --global --add flowhub.auth.token {}').format(token)
 
     def setup_repository_structure(self):


### PR DESCRIPTION
That way you only need to auth once. Maybe store it with the username field instead of 'token', to enable multiple user names?
