### PR TITLE
Improving issue creation interface

### DIFF
--- a/flowhub/engine.py
+++ b/flowhub/engine.py
@@ -1058,10 +1058,15 @@ class Engine(object):
         # regardless, close the tempfile.
         descr_f.close()
 
-        editor_result = subprocess.check_call(
-            "$EDITOR {}".format(descr_f.name),
-            shell=True
-        )
+        try:
+            editor_result = subprocess.check_call(
+                "$EDITOR {}".format(descr_f.name),
+                shell=True
+            )
+        except OSError:
+            if self.__debug > 2:
+                print "Hmm...are you on Windows?"
+            editor_result = 126
 
         if self.__debug > 3:
             print "result of $EDITOR: ", editor_result


### PR DESCRIPTION
Open `$EDITOR` if possible, rather than using the terminal (which is gross for input of a descriptions' length, and doesn't allow newlines)
