### PR TITLE
Unable to validate credentials: "scopes are invalid: user,repo,gist"

### DIFF
--- a/flowhub/engine.py
+++ b/flowhub/engine.py
@@ -108,7 +108,7 @@ class Engine(object):
 
             try:
                 auth = self._gh.get_user().create_authorization(
-                    'user,repo,gist',
+                    ['user', 'repo', 'gist'],
                     'Flowhub Client',
                 )
                 break


### PR DESCRIPTION
`flowhub init` keeps saying `Invalid username/password combination`, but it's actually catching this exception behind the scenes:

```
422 {u'message': u'Validation Failed', u'errors': [{u'field': u'scopes', u'message': u'scopes are invalid: user,repo,gist', u'code': u'custom', u'resource': u'OauthAccess'}]}
Invalid username/password combination.
```
