### PR TITLE
feature publish sometimes needs to be run twice to work

### DIFF
--- a/flowhub/core.py
+++ b/flowhub/core.py
@@ -177,12 +177,7 @@ def handle_feature_call(args, engine):
     elif args.action == 'publish':
         if not do_hook(args, engine, "pre-feature-publish"):
             return False
-        try:
-            engine.publish_feature(name=args.name)
-        except AssertionError:
-            # This is janky as shit, but running twice fixes it.
-            # see #14
-            engine.publish_feature(name=args.name)
+        engine.publish_feature(name=args.name)
 
     elif args.action == 'abandon':
         engine.abandon_feature(
@@ -190,17 +185,11 @@ def handle_feature_call(args, engine):
         )
 
     elif args.action == 'accepted':
-        try:
-            engine.accept_feature(
-                name=args.name,
-                delete_feature_branch=(not args.no_delete),
-            )
-        except AssertionError:
-            # see #14
-            engine.accept_feature(
-                name=args.name,
-                delete_feature_branch=(not args.no_delete),
-            )
+        engine.accept_feature(
+            name=args.name,
+            delete_feature_branch=(not args.no_delete),
+        )
+
     elif args.action == 'list':
         engine.list_features()
     else:


### PR DESCRIPTION
Fails with an assertion error:

``` python
Traceback (most recent call last):
  File "/Users/haak/virtualenvs/flowhub/bin/flowhub", line 5, in <module>
    pkg_resources.run_script('flowhub==0.2.2', 'flowhub')
  File "/Users/haak/virtualenvs/flowhub/lib/python2.7/site-packages/distribute-0.6.27-py2.7.egg/pkg_resources.py", line 499, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/Users/haak/virtualenvs/flowhub/lib/python2.7/site-packages/distribute-0.6.27-py2.7.egg/pkg_resources.py", line 1239, in run_script
    execfile(script_filename, namespace, namespace)
  File "/Users/haak/virtualenvs/flowhub/lib/python2.7/site-packages/flowhub-0.2.2-py2.7.egg/EGG-INFO/scripts/flowhub", line 5, in <module>
    core.run()
  File "/Users/haak/virtualenvs/flowhub/lib/python2.7/site-packages/flowhub-0.2.2-py2.7.egg/flowhub/core.py", line 774, in run
    handle_feature_call(args, e)
  File "/Users/haak/virtualenvs/flowhub/lib/python2.7/site-packages/flowhub-0.2.2-py2.7.egg/flowhub/core.py", line 625, in handle_feature_call
    name=args.name,
  File "/Users/haak/virtualenvs/flowhub/lib/python2.7/site-packages/flowhub-0.2.2-py2.7.egg/flowhub/decorators.py", line 10, in wrapper
    f(*args, summary=summary, **kwargs)
  File "/Users/haak/virtualenvs/flowhub/lib/python2.7/site-packages/flowhub-0.2.2-py2.7.egg/flowhub/core.py", line 210, in accept_feature
    self.canon.fetch()
  File "/Users/haak/virtualenvs/flowhub/lib/python2.7/site-packages/git/remote.py", line 593, in fetch
    return self._get_fetch_info_from_stderr(proc, progress or RemoteProgress())
  File "/Users/haak/virtualenvs/flowhub/lib/python2.7/site-packages/git/remote.py", line 539, in _get_fetch_info_from_stderr
    assert len(fetch_info_lines) == len(fetch_head_info), "len(%s) != len(%s)" % (fetch_head_info, fetch_info_lines)
AssertionError: len(["f83a38b643f975e1264dd2c7529c788f745549e4\t\tbranch 'feature/hotfixes' of https://github.com/haaksmash/flowhub\n", "608604bfcce7f2b2a1a356122574fc315468e3c7\tnot-for-merge\tbranch 'develop' of https://github.com/haaksmash/flowhub\n", "22ac01ee1c351cd554ee8e591c261a0fd9bfefab\tnot-for-merge\tbranch 'feature/better-setting-accessing' of https://github.com/haaksmash/flowhub\n", "4bc9e2c5f67c484b3715ac6a0db9d5f5dd2172f4\tnot-for-merge\tbranch 'feature/init' of https://github.com/haaksmash/flowhub\n", "9a64208c0c94ab841185412168e9f4c4c029c539\tnot-for-merge\tbranch 'master' of https://github.com/haaksmash/flowhub\n"]) != len(['POST git-upload-pack (943 bytes)', ' = [up to date]      feature/hotfixes -> origin/feature/hotfixes', '   bb18f67..608604b  develop    -> origin/develop', ' = [up to date]      feature/better-setting-accessing -> origin/feature/better-setting-accessing', ' = [up to date]      feature/init -> origin/feature/init', ' = [up to date]      master     -> origin/master'])
```
