### PR TITLE
Rewrite of Flowhub - releases

### DIFF
--- a/flowhub/cli.py
+++ b/flowhub/cli.py
@@ -79,12 +79,12 @@ class CLI(Base):
             # and remove the first line
             body = fnew.readlines()
             fnew.close()
-            long_form_succesful = True
+            long_form_successful = True
         else:
             body = self._input(
                 "Description (remember, you can use GitHub markdown):\n"
             )
-            long_form_succesful = False
+            long_form_successful = False
         return body, long_form_successful
 
     def build_engine(self, args):

--- a/flowhub/cli.py
+++ b/flowhub/cli.py
@@ -211,7 +211,37 @@ class CLI(Base):
         self._setup_parser_completers(completers)
 
     def _build_release_parser(self, parser):
-        pass
+        release_subs = parser.add_subparsers(dest='action')
+
+        rstart = release_subs.add_parser(
+            'start',
+            help="start a new release branch",
+        )
+        rstart.add_argument(
+            'name',
+            help="name (and tag) of the release branch.",
+        )
+
+        release_subs.add_parser(
+            'stage',
+            help="send a release branch to a staging environment",
+        )
+
+        rpublish = release_subs.add_parser(
+            'publish',
+            help="publish a release branch to production and trunk",
+        )
+        rpublish.add_argument(
+            'name',
+            nargs='?',
+            help="name of release to publish. if not specified, current branch is assumed.",
+        )
+        rpublish.add_argument(
+            '--no-cleanup',
+            action='store_true',
+            default=False,
+            help="do not delete the release branch after a successful publish",
+        )
 
     def _build_hotfix_parser(self, parser):
         pass
@@ -324,6 +354,17 @@ class CLI(Base):
         else:
             raise RuntimeError("Unimplemented command for features: {}".format(args.action))
 
+        return engine.get_summary()
+
+    def handle_release_invocation(self, args):
+        self.print_at_verbosity({3: 'handling release'})
+        engine = self.build_engine(args)
+        if args.action == 'start':
+            pass
+        elif args.action == 'stage':
+            pass
+        elif args.action == 'publish':
+            pass
         return engine.get_summary()
 
     def handle_unknown_invocation(self, args):

--- a/flowhub/cli.py
+++ b/flowhub/cli.py
@@ -360,11 +360,11 @@ class CLI(Base):
         self.print_at_verbosity({3: 'handling release'})
         engine = self.build_engine(args)
         if args.action == 'start':
-            pass
+            engine.start_release(args.name)
         elif args.action == 'stage':
-            pass
+            self._output("Gosh, sure be nice if this command did anything...")
         elif args.action == 'publish':
-            pass
+            engine.publish_release()
         return engine.get_summary()
 
     def handle_unknown_invocation(self, args):

--- a/flowhub/cli.py
+++ b/flowhub/cli.py
@@ -26,7 +26,13 @@ import argcomplete
 
 from flowhub.base import Base
 from flowhub.exceptions import Abort, HookFailure
-from flowhub.engine import Engine, DuplicateFeature, NeedsAuthorization, NotAFeatureBranch
+from flowhub.engine import (
+    Engine,
+    DuplicateFeature,
+    NeedsAuthorization,
+    NotAFeatureBranch,
+    ReleaseExists,
+)
 from flowhub.utilities import future_proof_print
 
 __version__ = '1.0.0'
@@ -360,7 +366,10 @@ class CLI(Base):
         self.print_at_verbosity({3: 'handling release'})
         engine = self.build_engine(args)
         if args.action == 'start':
-            engine.start_release(args.name)
+            try:
+                engine.start_release(args.name)
+            except ReleaseExists as error:
+                self._output("Please resolve the current release ({}) before starting a new one.".format(error.message))
         elif args.action == 'stage':
             self._output("Gosh, sure be nice if this command did anything...")
         elif args.action == 'publish':

--- a/flowhub/engine.py
+++ b/flowhub/engine.py
@@ -593,10 +593,11 @@ class Engine(Base):
             ),
         )
 
-        self.canon.push()
-        self.canon.push(tags=True)
+        if not self._offline:
+            self.canon.push()
+            self.canon.push(tags=True)
 
-        self.delete_branch(branch_name, should_delete_from_canon=True)
+        self.delete_branch(branch_name, should_delete_from_canon=not self._offline)
 
         self.switch_to_branch(self.develop.name)
 

--- a/flowhub/engine.py
+++ b/flowhub/engine.py
@@ -325,6 +325,8 @@ class Engine(Base):
                 "Pushed new commits to {}".format(remote_name),
             )
 
+        return had_new_commits
+
     def update_from_remote(self, branch_name, remote_name):
         if self._offline:
             return None
@@ -431,7 +433,7 @@ class Engine(Base):
             raise HookFailure('pre-feature-publish')
 
         already_tracking = self._find_branch(branch_name).tracking_branch is not None
-        self.push_to_remote(branch_name, self.origin.name, not already_tracking)
+        had_new_commits = self.push_to_remote(branch_name, self.origin.name, not already_tracking)
 
         if not self._offline:
             request_results = self.connector.make_request(
@@ -452,7 +454,7 @@ class Engine(Base):
                             )
                         )[1:],
                     )
-                else:
+                elif had_new_commits:
                     self.add_to_summary_items(
                         textwrap.dedent("""
                             New commits added to existing request

--- a/flowhub/engine.py
+++ b/flowhub/engine.py
@@ -485,7 +485,7 @@ class Engine(Base):
             base_branch = self._find_remote_branch(self.canon.name, self.develop.name)
 
         if len(existing_releases) != 0:
-            raise ReleaseExists(existing_releases[0])
+            raise ReleaseExists(existing_releases.pop())
 
         branch_name = "{}{}".format(
             RELEASE_PREFIX,

--- a/flowhub/engine.py
+++ b/flowhub/engine.py
@@ -507,7 +507,7 @@ class Engine(Base):
                     title=title,
                     labels='\n\t[{}]'.format(' '.join(labels)) if labels else '',
                     url=result.url,
-                ),
+                )[1:],
             ),
         )
 


### PR DESCRIPTION
Following up on #87, this re-implements the `release` subset of commands:
- `start`
- `stage` (a joke)
- `publish`

as well as re-enabling the release cycle hooks.

